### PR TITLE
Upgrades Retool to 2.70.21

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ name: retool
 description: A Helm chart for Kubernetes
 type: application
 version: 4.2.3
-appVersion: "2.66.91"
+appVersion: "2.70.21"
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com


### PR DESCRIPTION
Upgrades Retool to 2.70.21 to allow for Jira integration.