### PR TITLE
[CMP-337] Updates Retool to 2.90.11

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ name: retool
 description: A Helm chart for Kubernetes
 type: application
 version: 4.3.1
-appVersion: "2.75.20"
+appVersion: "2.90.11"
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com


### PR DESCRIPTION
Updates our forked Retool Helm chart to the latest stable version of Retool (2.90.11).