### PR TITLE
[IAT-391] Upgrades Retool to latest version 2.100.2

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ name: retool
 description: A Helm chart for Kubernetes
 type: application
 version: 4.3.2
-appVersion: "2.90.11"
+appVersion: "2.100.2"
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com


### PR DESCRIPTION
This PR upgrades Retool to the latest version 2.100.2 which will get us up to date on the development environment and give us some bug fixes.