### PR TITLE
[EVE-6534] Update env vars arrangement

### DIFF
--- a/templates/deployment_backend.yaml
+++ b/templates/deployment_backend.yaml
@@ -94,10 +94,6 @@ spec:
                 key: postgresql-password
           - name: SCIM_AUTH_TOKEN
             value: {{ default "" .Values.config.auth.onelogin.scimAuthToken | quote }}
-          - name: RESTRICTED_DOMAIN
-            value: {{ default "" .Values.config.ssoRestrictedDomain | quote }}
-          - name: BASE_DOMAIN
-            value: {{ default "" .Values.config.baseDomain | quote }}
           - name: GITHUB_APP_ID
             value: {{ default "" .Values.config.githubAppId | quote }}
           - name: GITHUB_APP_INSTALLATION_ID
@@ -105,6 +101,10 @@ spec:
           - name: GITHUB_APP_PRIVATE_KEY
             value: {{ default "" .Values.config.githubAppPrivateKey | quote }}
           {{- end }}
+          - name: RESTRICTED_DOMAIN
+            value: {{ default "" .Values.config.ssoRestrictedDomain | quote }}
+          - name: BASE_DOMAIN
+            value: {{ default "" .Values.config.baseDomain | quote }}
           {{- range $key, $value := .Values.env }}
           - name: "{{ $key }}"
             value: "{{ $value }}"

--- a/templates/deployment_jobs.yaml
+++ b/templates/deployment_jobs.yaml
@@ -91,19 +91,19 @@ spec:
                 name: {{ template "retool.fullname" . }}
           {{- end }}
                 key: postgresql-password
-          - name: RESTRICTED_DOMAIN
-            value: {{ .Values.config.ssoRestrictedDomain | default "" | quote }}
-          - name: BASE_DOMAIN
-            value: {{ .Values.config.baseDomain | quote }}
           - name: GITHUB_APP_ID
             value: {{ .Values.config.githubAppId | default "" | quote }}
           - name: GITHUB_APP_INSTALLATION_ID
             value: {{ .Values.config.githubAppInstallationId | default "" | quote }}
           - name: GITHUB_APP_PRIVATE_KEY
             value: {{ .Values.config.githubAppPrivateKey | default "" | quote }}
+          {{- end }}
+          - name: RESTRICTED_DOMAIN
+            value: {{ .Values.config.ssoRestrictedDomain | default "" | quote }}
+          - name: BASE_DOMAIN
+            value: {{ .Values.config.baseDomain | quote }}
           - name: VERSION_CONTROL_LOCKED
             value: {{ .Values.config.versionControlLocked | default "" | quote }}
-          {{- end }}
           {{- range $key, $value := .Values.env }}
           - name: "{{ $key }}"
             value: "{{ $value }}"

--- a/values.yaml
+++ b/values.yaml
@@ -76,7 +76,7 @@ ingress:
   # servicePort: service-port
 
 postgresql:
-  enabled: true
+  enabled: false
   ssl_enabled: false
   postgresqlDatabase: hammerhead_production
   postgresqlUsername: retool


### PR DESCRIPTION
Doing this to support new installation where we use values.externalSecret with only sensitive vars encrypted instead of the whole values.yaml
https://git.ringcentral.com/events/infrastructure/gitops/argocd/-/blob/main/prod/dub08/retool-dev/secrets/retool.yaml
Also disabling self-managed postres by default